### PR TITLE
Github actions files created

### DIFF
--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: pull_request
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci --unsafe-perm
+      - run: npm run build
+      - run: npm test

--- a/.github/workflow/npm-publish.yml
+++ b/.github/workflow/npm-publish.yml
@@ -1,0 +1,21 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci --unsafe-perm
+      - run: npm run build
+      - run: npm test
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflow/storybook.yml
+++ b/.github/workflow/storybook.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci --unsafe-perm
+      - run: npm run build
+      - run: npm test
+      - run: npm run deploy


### PR DESCRIPTION
`video-player` repository must be an open source. We cannot use `AWS CodeBuild` for open-source repositories. 
This PR migrates repository deployment from `CodeBuild` to `Github Actions`.
Relates with: https://github.com/Collaborne/backlog/issues/1013