### PR TITLE
MediaPlayer: Integration tests for first time media playing

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"build:docs": "typedoc",
 		"lint": "npm run lint:ts",
 		"lint:ts": "eslint --report-unused-disable-directives $(node -p 'require(\"./tsconfig.test.json\").include.map(include => `'\\${include}.\\{js,ts,tsx\\}'`).join(\" \")')",
+		"test:coverage": "cross-env CI=1 SKIP_PREFLIGHT_CHECK=true react-scripts test --env=jsdom --coverage .",
 		"test": "run-s lint test:build test:unit",
 		"test:build": "npm run build:locales && tsc --noEmit -p tsconfig.test.json",
 		"test:unit": "cross-env CI=1 SKIP_PREFLIGHT_CHECK=true react-scripts test --env=jsdom --passWithNoTests",
@@ -123,5 +124,19 @@
 		"eslint-config-standard-react": {
 			"eslint": "^8"
 		}
+	},
+	"jest": {
+		"collectCoverageFrom": [
+			"./src/**"
+		],
+		"coverageReporters": [
+			"text"
+		],
+		"coveragePathIgnorePatterns": [
+			"/src/types",
+			"/src/react-app-env.d.ts",
+			"/src/theme.ts",
+			"/src/.eslintrc.json"
+		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -136,7 +136,8 @@
 			"/src/types",
 			"/src/react-app-env.d.ts",
 			"/src/theme.ts",
-			"/src/.eslintrc.json"
+			"/src/.eslintrc.json",
+			"index.ts"
 		]
 	}
 }

--- a/src/components/animated-icon-wrapper/AnimatedIconWrapper.tsx
+++ b/src/components/animated-icon-wrapper/AnimatedIconWrapper.tsx
@@ -11,6 +11,7 @@ interface AnimatedIconWrapperProps extends PropsWithChildren {
 	durationMs: number;
 	startAnimation?: boolean;
 	className?: string;
+	'data-testid'?: string;
 }
 /**
  * Component used as a wrapper for transitions
@@ -21,6 +22,7 @@ export const AnimatedIconWrapper: FC<AnimatedIconWrapperProps> = ({
 	children,
 	startAnimation,
 	className,
+	'data-testid': dataTestId,
 }) => {
 	const {
 		classes: { root },
@@ -28,7 +30,7 @@ export const AnimatedIconWrapper: FC<AnimatedIconWrapperProps> = ({
 	} = useAnimatedIconWrapperStyles();
 
 	return (
-		<Transition in={startAnimation} timeout={durationMs}>
+		<Transition in={startAnimation} timeout={durationMs} data-testid="asdasd">
 			{state => {
 				return (
 					<div
@@ -37,6 +39,7 @@ export const AnimatedIconWrapper: FC<AnimatedIconWrapperProps> = ({
 							...defaultStyle(durationMs),
 							...transitionStyles[state],
 						}}
+						data-testid={dataTestId}
 					>
 						{children}
 					</div>

--- a/src/components/big-centered-button/BigCenteredButton.tsx
+++ b/src/components/big-centered-button/BigCenteredButton.tsx
@@ -8,7 +8,7 @@ export interface BigCenteredButtonProps {
 	Icon: ComponentType<SvgIconProps>;
 	onClick?: VoidFunction;
 	classNames?: string;
-	iconButtonProps?: IconButtonProps;
+	iconButtonProps?: IconButtonProps & { 'data-testid'?: string };
 }
 
 /**

--- a/src/components/bottom-control-buttons/BottomControlButtons.tsx
+++ b/src/components/bottom-control-buttons/BottomControlButtons.tsx
@@ -2,6 +2,7 @@ import Grid from '@mui/material/Grid';
 import { FC, memo, ReactNode } from 'react';
 
 import { useIsAudio } from '../../hooks';
+import { BOTTOM_CONTROL_BUTTONS } from '../../utils';
 
 import { useBottomControlButtonsHook } from './useBottomControlButtonsHook';
 import { useBottomControlButtonsStyles } from './useBottomControlButtonsStyles';
@@ -9,6 +10,7 @@ import { useBottomControlButtonsStyles } from './useBottomControlButtonsStyles';
 export interface BottomControlButtonsProps {
 	className?: string;
 	children: ReactNode;
+	'data-testid'?: string;
 }
 
 /**
@@ -17,7 +19,11 @@ export interface BottomControlButtonsProps {
  * @category UI Controls
  */
 export const BottomControlButtons: FC<BottomControlButtonsProps> = memo(
-	({ className, children }) => {
+	({
+		className,
+		children,
+		'data-testid': dataTestId = BOTTOM_CONTROL_BUTTONS,
+	}) => {
 		const isAudio = useIsAudio();
 		const { classes, cx } = useBottomControlButtonsStyles();
 
@@ -34,7 +40,7 @@ export const BottomControlButtons: FC<BottomControlButtonsProps> = memo(
 				alignItems="center"
 				justifyContent="space-between"
 				direction="row"
-				data-testid="bottom-control-panel"
+				data-testid={dataTestId}
 			>
 				{children}
 			</Grid>

--- a/src/components/bottom-control-buttons/__tests__/BottomControlButtons.spec.tsx
+++ b/src/components/bottom-control-buttons/__tests__/BottomControlButtons.spec.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import {
 	PAUSE_ICON,
+	PIP_BUTTON,
 	PLAYBACK_RATES,
 	PLAY_ICON,
 	SECONDS_TO_SKIP,
@@ -104,7 +105,7 @@ describe('<BottomControlButtons />', () => {
 		const { getByTestId, mediaStore } = setupMediaProvider(
 			<BottomControlButtons />,
 		);
-		const pip = getByTestId('icon-pip');
+		const pip = getByTestId(PIP_BUTTON);
 		await userEvent.click(pip);
 		expect(mediaStore.isPip).toBeTruthy();
 		expect(mediaStore.hasPipTriggeredByClick).toBeTruthy();

--- a/src/components/bottom-control-buttons/__tests__/BottomControlButtons.spec.tsx
+++ b/src/components/bottom-control-buttons/__tests__/BottomControlButtons.spec.tsx
@@ -1,5 +1,10 @@
 import '@testing-library/jest-dom';
-import { PLAYBACK_RATES, SECONDS_TO_SKIP } from '../../../utils/constants';
+import {
+	PAUSE_ICON,
+	PLAYBACK_RATES,
+	PLAY_ICON,
+	SECONDS_TO_SKIP,
+} from '../../../utils/constants';
 import {
 	act,
 	setupMediaProvider,
@@ -34,17 +39,17 @@ const BottomControlButtons = () => {
 describe('<BottomControlButtons />', () => {
 	it('displays play button on first mount', async () => {
 		const { getByTestId } = setupMediaProvider(<BottomControlButtons />);
-		expect(getByTestId('icon-play')).toBeInTheDocument();
+		expect(getByTestId(PLAY_ICON)).toBeInTheDocument();
 	});
 
 	it('click on play/pause actions', async () => {
 		const { getByTestId, mediaStore } = setupMediaProvider(
 			<BottomControlButtons />,
 		);
-		const playButton = getByTestId('icon-play');
+		const playButton = getByTestId(PLAY_ICON);
 		await userEvent.click(playButton);
 		expect(mediaStore.isPlaying).toBeTruthy();
-		const pauseButton = getByTestId('icon-pause');
+		const pauseButton = getByTestId(PAUSE_ICON);
 		expect(pauseButton).toBeInTheDocument();
 		await userEvent.click(pauseButton);
 		expect(mediaStore.isPlaying).toBeFalsy();

--- a/src/components/bottom-control-buttons/components/FullscreenButton.tsx
+++ b/src/components/bottom-control-buttons/components/FullscreenButton.tsx
@@ -5,6 +5,7 @@ import shallow from 'zustand/shallow';
 import { useMediaStore } from '../../../context';
 import { useIsAudio } from '../../../hooks/use-is-audio';
 import { useOnHoveredControlElement } from '../../../hooks/use-on-hovered-element';
+import { FULLSCREEN_BUTTON } from '../../../utils';
 import { FullscreenEnterIcon, FullscreenExitIcon } from '../../icons';
 type FullscreenIcons = {
 	FullscreenEnter: ComponentType<SvgIconProps>;
@@ -13,6 +14,7 @@ type FullscreenIcons = {
 interface FullscreenButtonProps extends IconButtonProps {
 	Icons?: FullscreenIcons;
 	svgIconProps?: SvgIconProps;
+	'data-test-id'?: string;
 }
 /**
  * @category React Component
@@ -24,6 +26,7 @@ export const FullscreenButton: FC<FullscreenButtonProps> = ({
 		FullscreenExit: FullscreenExitIcon,
 	},
 	svgIconProps,
+	'data-test-id': dataTestId = FULLSCREEN_BUTTON,
 	...props
 }) => {
 	const [isFullscreen, requestFullscreen, exitFullscreen] = useMediaStore(
@@ -49,6 +52,7 @@ export const FullscreenButton: FC<FullscreenButtonProps> = ({
 			onMouseLeave={onMouseLeave}
 			size="medium"
 			onClick={onFullscreen}
+			data-testid={dataTestId}
 			{...props}
 		>
 			{!isFullscreen ? (

--- a/src/components/bottom-control-buttons/components/PictureInPictureButton.tsx
+++ b/src/components/bottom-control-buttons/components/PictureInPictureButton.tsx
@@ -4,11 +4,13 @@ import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../../../context';
 import { useOnHoveredControlElement } from '../../../hooks/use-on-hovered-element';
+import { PIP_BUTTON } from '../../../utils';
 import { PiPIcon } from '../../icons';
 
 interface PictureInPictureButtonProps extends IconButtonProps {
 	Icon?: ComponentType<SvgIconProps>;
 	svgIconProps?: SvgIconProps;
+	'data-testid'?: string;
 }
 
 /**
@@ -18,6 +20,7 @@ interface PictureInPictureButtonProps extends IconButtonProps {
 export const PictureInPictureButton: FC<PictureInPictureButtonProps> = ({
 	Icon = PiPIcon,
 	svgIconProps,
+	'data-testid': dataTestId = PIP_BUTTON,
 	...props
 }) => {
 	const { onMouseEnter, onMouseLeave } = useOnHoveredControlElement();
@@ -39,7 +42,7 @@ export const PictureInPictureButton: FC<PictureInPictureButtonProps> = ({
 			onMouseLeave={onMouseLeave}
 			size="medium"
 			onClick={togglePip}
-			data-testid="icon-pip"
+			data-testid={dataTestId}
 			{...props}
 		>
 			<Icon fontSize="medium" {...svgIconProps} />

--- a/src/components/bottom-control-buttons/components/PlayPauseReplay.tsx
+++ b/src/components/bottom-control-buttons/components/PlayPauseReplay.tsx
@@ -5,12 +5,19 @@ import { ComponentType, FC } from 'react';
 
 import { useOnHoveredControlElement } from '../../../hooks/use-on-hovered-element';
 import { usePlayPauseReplayHook } from '../../../hooks/use-play-pause-replay';
+import {
+	PAUSE_ICON,
+	PLAY_ICON,
+	PLAY_PAUSE_REPLAY,
+	REPLAY_ICON,
+} from '../../../utils';
 
 interface PlayPauseReplayProps extends IconButtonProps {
 	svgClassName?: string;
 	Icons?: Record<'Play' | 'Replay' | 'Pause', ComponentType<SvgIconProps>>;
 	svgIconSize?: SvgIconProps['fontSize'];
 	skipSeconds?: number;
+	'data-testid'?: string;
 }
 
 /**
@@ -23,6 +30,7 @@ export const PlayPauseReplay: FC<PlayPauseReplayProps> = ({
 	Icons = { Pause: PauseOutlined, Play: PlayArrow, Replay: ReplayOutlined },
 	svgIconSize = 'inherit',
 	skipSeconds,
+	'data-testid': dataTestId = PLAY_PAUSE_REPLAY,
 	...props
 }) => {
 	const { isFinished, isPlaying, onPlay, onStop } = usePlayPauseReplayHook();
@@ -48,27 +56,28 @@ export const PlayPauseReplay: FC<PlayPauseReplayProps> = ({
 			size="medium"
 			className={className}
 			onClick={handleClick}
+			data-testid={dataTestId}
 			{...props}
 		>
 			{isFinished && (
 				<Replay
 					className={svgClassName}
 					fontSize={svgIconSize}
-					data-testid="icon-replay"
+					data-testid={REPLAY_ICON}
 				/>
 			)}
 			{isPlaying && (
 				<Pause
 					className={svgClassName}
 					fontSize={svgIconSize}
-					data-testid="icon-pause"
+					data-testid={PAUSE_ICON}
 				/>
 			)}
 			{!isFinished && !isPlaying && (
 				<Play
 					className={svgClassName}
 					fontSize={svgIconSize}
-					data-testid="icon-play"
+					data-testid={PLAY_ICON}
 				/>
 			)}
 		</IconButton>

--- a/src/components/centered-bottom-playback/CenteredBottomPlayback.tsx
+++ b/src/components/centered-bottom-playback/CenteredBottomPlayback.tsx
@@ -3,7 +3,10 @@ import { FC } from 'react';
 
 import { useMediaStore } from '../../context';
 import { useIsAudio } from '../../hooks';
-import { PLAYBACK_RATES } from '../../utils/constants';
+import {
+	CENTERED_BOTTOM_PLAYBACK,
+	PLAYBACK_RATES,
+} from '../../utils/constants';
 import { MultiplySymbol } from '../../utils/MultiplySymbol';
 
 import { PlaybackRateButtonStyled } from './components/PlaybackRateButtonStyled';
@@ -74,7 +77,10 @@ export const CenteredBottomPlayback: FC<CenteredBottomPlaybackProps> = ({
 	}
 
 	return (
-		<div className={cx(wrapper, className)} data-testid="c-playbackRate">
+		<div
+			className={cx(wrapper, className)}
+			data-testid={CENTERED_BOTTOM_PLAYBACK}
+		>
 			<div className={playbackWrapper}>
 				{PLAYBACK_RATES.map(item => (
 					<PlayBackButton
@@ -82,7 +88,7 @@ export const CenteredBottomPlayback: FC<CenteredBottomPlaybackProps> = ({
 						active={playbackRate}
 						onChangeRate={onChangePlaybackRate}
 						playbackRate={item}
-						data-testid={`c-playbackRate-${item}`}
+						data-testid={`${CENTERED_BOTTOM_PLAYBACK}-${item}`}
 					/>
 				))}
 			</div>

--- a/src/components/centered-bottom-playback/__tests__/CeneredBottomPlayback.spec.tsx
+++ b/src/components/centered-bottom-playback/__tests__/CeneredBottomPlayback.spec.tsx
@@ -1,12 +1,13 @@
 import '@testing-library/jest-dom';
+import { CENTERED_BOTTOM_PLAYBACK } from '../../../utils/constants';
 import { userEvent, renderWithProviders } from '../../../utils/testing-render';
 import { CenteredBottomPlayback } from '../CenteredBottomPlayback';
 
 describe('<CenteredBottomPlayback />', () => {
 	it('activates the playback rate button that was clicked last', async () => {
 		const { getByTestId } = renderWithProviders(<CenteredBottomPlayback />);
-		const firstPlaybackRate = getByTestId('c-playbackRate-1');
-		const secondPlaybackRate = getByTestId('c-playbackRate-2');
+		const firstPlaybackRate = getByTestId(`${CENTERED_BOTTOM_PLAYBACK}-1`);
+		const secondPlaybackRate = getByTestId(`${CENTERED_BOTTOM_PLAYBACK}-2`);
 		await userEvent.click(firstPlaybackRate);
 		expect(secondPlaybackRate).toHaveAttribute('data-is-active', 'false');
 		expect(firstPlaybackRate).toHaveAttribute('data-is-active', 'true');

--- a/src/components/centered-play-button/CenteredPlayButton.tsx
+++ b/src/components/centered-play-button/CenteredPlayButton.tsx
@@ -3,6 +3,7 @@ import { FC } from 'react';
 
 import { useMediaStore } from '../../context';
 import { useIsAudio } from '../../hooks';
+import { CENTERED_PLAY_BUTTON } from '../../utils/constants';
 import { BigCenteredButton } from '../big-centered-button/BigCenteredButton';
 import { BigPlayIcon } from '../icons/BigPlayIcon';
 
@@ -33,7 +34,10 @@ export const CenteredPlayButton: FC<CenteredPlayButtonProps> = ({
 			Icon={BigPlayIcon}
 			onClick={play}
 			classNames={classNames}
-			iconButtonProps={iconButtonProps}
+			iconButtonProps={{
+				'data-testid': CENTERED_PLAY_BUTTON,
+				...iconButtonProps,
+			}}
 		/>
 	);
 };

--- a/src/components/controls/Controls.tsx
+++ b/src/components/controls/Controls.tsx
@@ -1,12 +1,14 @@
 import { FC, ReactNode } from 'react';
 
 import { useMediaStore } from '../../context';
+import { CONTROLS } from '../../utils';
 
 import { useControlsStyles } from './useControlsStyles';
 
 export interface ControlProps {
 	children: ReactNode;
 	className?: string;
+	'data-testid'?: string;
 }
 
 /**
@@ -14,7 +16,11 @@ export interface ControlProps {
  * @category React Component
  * @category UI Controls
  */
-export const Controls: FC<ControlProps> = ({ children, className }) => {
+export const Controls: FC<ControlProps> = ({
+	children,
+	className,
+	'data-testid': dataTestId = CONTROLS,
+}) => {
 	const showControls = useMediaStore(state => state.showControls);
 
 	// Controls styles
@@ -26,5 +32,9 @@ export const Controls: FC<ControlProps> = ({ children, className }) => {
 		return null;
 	}
 
-	return <div className={classNameControls}>{children}</div>;
+	return (
+		<div className={classNameControls} data-testid={dataTestId}>
+			{children}
+		</div>
+	);
 };

--- a/src/components/draggable-popover/DraggablePopover.tsx
+++ b/src/components/draggable-popover/DraggablePopover.tsx
@@ -6,6 +6,7 @@ import { Rnd, Props as RndProps } from 'react-rnd';
 import { useMediaStore } from '../../context';
 import { useIsAudio } from '../../hooks';
 import { usePipControlsContext } from '../../hooks/use-pip-controls-context';
+import { DRAGGABLE_POPOVER } from '../../utils';
 import { MediaContainerProps } from '../media-container/MediaContainer';
 import { MediaPoster } from '../media-poster/MediaPoster';
 
@@ -25,6 +26,7 @@ export interface DraggablePopoverProps
 	rndProps?: RndProps;
 	className?: string;
 	audioPlaceholder?: string;
+	'data-testid'?: string;
 }
 
 /**
@@ -40,6 +42,7 @@ export const DraggablePopover: FC<DraggablePopoverProps> = memo(
 		audioPlaceholder,
 		xAxisDistance,
 		yAxisDistance,
+		'data-testid': dataTestId = DRAGGABLE_POPOVER,
 		...props
 	}) => {
 		const { PIPControls } = usePipControlsContext();
@@ -65,7 +68,7 @@ export const DraggablePopover: FC<DraggablePopoverProps> = memo(
 
 		return (
 			<Portal {...props}>
-				<div className={portalWrapper}>
+				<div className={portalWrapper} data-testid={dataTestId}>
 					<Rnd
 						bounds="parent"
 						default={{

--- a/src/components/media-container/MediaContainer.tsx
+++ b/src/components/media-container/MediaContainer.tsx
@@ -4,6 +4,7 @@ import shallow from 'zustand/shallow';
 
 import { useMediaStore } from '../../context/MediaProvider';
 import { useIsAudio } from '../../hooks';
+import { MEDIA_CONTAINER } from '../../utils';
 import { CorePlayerProps } from '../core-player/CorePlayer';
 import { DraggablePopover } from '../draggable-popover/DraggablePopover';
 import { MediaPoster } from '../media-poster/MediaPoster';
@@ -71,6 +72,7 @@ export const MediaContainer: FC<MediaContainerProps> = memo(
 				onMouseEnter={onMouseEnter}
 				onMouseLeave={onMouseLeave}
 				onMouseMove={onMouseMove}
+				data-testid={MEDIA_CONTAINER}
 			>
 				<DraggablePopover
 					disablePortal={!isPip}

--- a/src/components/media-player/__test__/MediaPlayer.spec.tsx
+++ b/src/components/media-player/__test__/MediaPlayer.spec.tsx
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import { useMediaStore } from '../../../context/MediaProvider';
 import { MediaStore } from '../../../store/media-store';
 import {
+	BOTTOM_CONTROL_BUTTONS,
 	CENTERED_BOTTOM_PLAYBACK,
 	CENTERED_PLAY_BUTTON,
 	DEFAULT_EVENT_ANIMATION_DURATION,
@@ -46,7 +47,7 @@ const setupMediaPlayer = () => {
 
 describe('<MediaPlayer>', () => {
 	afterEach(cleanup);
-	describe.skip('initialization', () => {
+	describe('initialization', () => {
 		it('media has not started before', async () => {
 			const { getByTestId, mediaStore } = setupMediaPlayer();
 			// wait 1 sec to mount state and load initial data
@@ -162,6 +163,20 @@ describe('<MediaPlayer>', () => {
 			await userEvent.click(playPauseReplayBtn);
 			expect(playEl.style.display).toBe('block');
 			expect(pauseEl.style.display).toBe('none');
+		});
+	});
+	describe('Hovering player layout', () => {
+		it('<BottomControls /> are not displayed if media has not started', async () => {
+			const { getByTestId, queryByTestId } = setupMediaPlayer();
+			// wait 1 sec to mount state and load initial data
+			await act(async () => await sleep(2000));
+
+			const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
+			const bottomButtons = queryByTestId(BOTTOM_CONTROL_BUTTONS);
+			expect(bottomButtons).not.toBeInTheDocument();
+
+			await userEvent.click(startBtn);
+			expect(getByTestId(BOTTOM_CONTROL_BUTTONS)).toBeInTheDocument();
 		});
 	});
 });

--- a/src/components/media-player/__test__/MediaPlayer.spec.tsx
+++ b/src/components/media-player/__test__/MediaPlayer.spec.tsx
@@ -1,0 +1,98 @@
+import { render, cleanup, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { useMediaStore } from '../../../context/MediaProvider';
+import { MediaStore } from '../../../store/media-store';
+import {
+	CENTERED_BOTTOM_PLAYBACK,
+	CENTERED_PLAY_BUTTON,
+	sleep,
+	userEvent,
+} from '../../../utils';
+import { MediaPlayer } from '../MediaPlayer';
+
+// Start the playback.
+global.window.HTMLMediaElement.prototype.play = async function playMock() {
+	this.dispatchEvent(new Event('play'));
+};
+const URL =
+	'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4';
+
+// A test setup for MediaPlayer, that can access `MediaStore` from `MediaProvider`
+const setupMediaPlayer = () => {
+	const returnVal = {} as MediaStore;
+	function NullComponent() {
+		const mediaStore = useMediaStore();
+		Object.assign(returnVal, mediaStore);
+		return null;
+	}
+	function TestComponent() {
+		return (
+			<MediaPlayer url={URL}>
+				<NullComponent />
+			</MediaPlayer>
+		);
+	}
+	return { ...render(<TestComponent />), mediaStore: returnVal };
+};
+
+describe('<MediaPlayer>', () => {
+	afterEach(cleanup);
+	describe('initialization', () => {
+		it('media has not started before', async () => {
+			const { getByTestId, mediaStore } = setupMediaPlayer();
+			// wait 1 sec to mount state and load initial data
+			await act(async () => await sleep(1000));
+
+			const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
+			const playbackRateDiv = getByTestId(CENTERED_BOTTOM_PLAYBACK);
+			const playbackRate1Btn = getByTestId(`${CENTERED_BOTTOM_PLAYBACK}-1`);
+
+			expect(mediaStore.hasPlayedOrSeeked).toBeFalsy();
+			expect(startBtn).toBeInTheDocument();
+			expect(playbackRateDiv).toBeInTheDocument();
+			expect(playbackRate1Btn).toBeInTheDocument();
+			expect(playbackRate1Btn).toHaveAttribute('data-is-active', 'true');
+		});
+		describe('first time play', () => {
+			it('click on <CenteredPlayButton /> start playing', async () => {
+				const { getByTestId, mediaStore } = setupMediaPlayer();
+				await act(async () => await sleep(1000));
+				const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
+				const playbackRateDiv = getByTestId(CENTERED_BOTTOM_PLAYBACK);
+
+				await userEvent.click(startBtn);
+
+				expect(startBtn).not.toBeInTheDocument();
+				expect(mediaStore.isPlaying).toBeTruthy();
+				expect(mediaStore.hasPlayedOrSeeked).toBeTruthy();
+				expect(playbackRateDiv).not.toBeInTheDocument();
+			});
+			it('click on <CenteredBottomPlayback /> do not start playing', async () => {
+				const { getByTestId, mediaStore } = setupMediaPlayer();
+				await act(async () => await sleep(1000));
+				const playbackRate2Btn = getByTestId(`${CENTERED_BOTTOM_PLAYBACK}-2`);
+
+				await userEvent.click(playbackRate2Btn);
+
+				expect(mediaStore.isPlaying).toBeFalsy();
+				expect(mediaStore.hasPlayedOrSeeked).toBeFalsy();
+				expect(mediaStore.playbackRate).toBe(2);
+			});
+			it('click on media-player layout start playing and hide <CenteredPlayButton /> and <CenteredPlayButton /> ', async () => {
+				const { getByTestId, mediaStore } = setupMediaPlayer();
+				await act(async () => await sleep(1000));
+				const mediaPlayerDiv = getByTestId('media-player');
+				const playbackRateDiv = getByTestId(CENTERED_BOTTOM_PLAYBACK);
+				const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
+
+				await userEvent.click(mediaPlayerDiv);
+
+				expect(mediaStore.isPlaying).toBeTruthy();
+				expect(mediaStore.hasPlayedOrSeeked).toBeTruthy();
+				expect(playbackRateDiv).not.toBeInTheDocument();
+				expect(startBtn).not.toBeInTheDocument();
+			});
+		});
+	});
+});

--- a/src/components/media-player/__test__/MediaPlayer.spec.tsx
+++ b/src/components/media-player/__test__/MediaPlayer.spec.tsx
@@ -11,6 +11,7 @@ import {
 	MEDIA_CONTAINER,
 	OVERLAY_HIDE_DELAY,
 	PAUSE_ANIMATION,
+	PIP_BUTTON,
 	PLAY_ANIMATION,
 	PLAY_PAUSE_REPLAY,
 	REACT_PLAYER,
@@ -207,9 +208,56 @@ describe('<MediaPlayer>', () => {
 
 			await userEvent.hover(getByTestId(MEDIA_CONTAINER));
 			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).toBeInTheDocument();
-			// because onMouseEvent is throttled, overlay can be hidden for a +-1sec
+			// because onMouseEvent is throttled, hiding can occur for a upt to 1sec delay
 			await act(async () => await sleep(OVERLAY_HIDE_DELAY + 1000));
 			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).not.toBeInTheDocument();
+		});
+		it(`display when paused`, async () => {
+			const { getByTestId, queryByTestId, mediaStore } = setupMediaPlayer();
+			// wait 1 ms to mount state and load initial data
+			await act(async () => await sleep(1));
+
+			const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
+
+			await userEvent.click(startBtn);
+			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).toBeInTheDocument();
+
+			await userEvent.click(getByTestId(PLAY_PAUSE_REPLAY));
+			expect(mediaStore.isPlaying).toBeFalsy();
+
+			await userEvent.unhover(getByTestId(MEDIA_CONTAINER));
+			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).toBeInTheDocument();
+		});
+		it(`always display when an button of <BottomControlsButtons/> is hovered`, async () => {
+			const { getByTestId, queryByTestId, mediaStore } = setupMediaPlayer();
+			// wait 1 ms to mount state and load initial data
+			await act(async () => await sleep(1));
+
+			const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
+
+			await userEvent.click(startBtn);
+			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).toBeInTheDocument();
+			expect(mediaStore.isPlaying).toBeTruthy();
+
+			await userEvent.hover(getByTestId(PLAY_PAUSE_REPLAY));
+			// add delay 1sec - for be certain sure that should wait enough
+			await act(async () => await sleep(OVERLAY_HIDE_DELAY + 1000));
+			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).toBeInTheDocument();
+		});
+		it(`always display when PIP mode is on`, async () => {
+			const { getByTestId, queryByTestId, mediaStore } = setupMediaPlayer();
+			// wait 1 ms to mount state and load initial data
+			await act(async () => await sleep(1));
+
+			const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
+
+			await userEvent.click(startBtn);
+
+			await userEvent.click(getByTestId(PIP_BUTTON));
+			expect(mediaStore.isPlaying).toBeTruthy();
+			expect(mediaStore.isPip).toBeTruthy();
+
+			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).toBeInTheDocument();
 		});
 	});
 });

--- a/src/components/media-player/__test__/MediaPlayer.spec.tsx
+++ b/src/components/media-player/__test__/MediaPlayer.spec.tsx
@@ -8,6 +8,8 @@ import {
 	CENTERED_BOTTOM_PLAYBACK,
 	CENTERED_PLAY_BUTTON,
 	DEFAULT_EVENT_ANIMATION_DURATION,
+	MEDIA_CONTAINER,
+	OVERLAY_HIDE_DELAY,
 	PAUSE_ANIMATION,
 	PLAY_ANIMATION,
 	PLAY_PAUSE_REPLAY,
@@ -21,6 +23,8 @@ import { MediaPlayer } from '../MediaPlayer';
 global.window.HTMLMediaElement.prototype.play = async function playMock() {
 	this.dispatchEvent(new Event('play'));
 };
+
+// Pause the playback.
 global.window.HTMLMediaElement.prototype.pause = async function playMock() {
 	this.dispatchEvent(new Event('pause'));
 };
@@ -50,8 +54,8 @@ describe('<MediaPlayer>', () => {
 	describe('initialization', () => {
 		it('media has not started before', async () => {
 			const { getByTestId, mediaStore } = setupMediaPlayer();
-			// wait 1 sec to mount state and load initial data
-			await act(async () => await sleep(1000));
+			// wait 1 ms to mount state and load initial data
+			await act(async () => await sleep(1));
 
 			const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
 			const playbackRateDiv = getByTestId(CENTERED_BOTTOM_PLAYBACK);
@@ -66,8 +70,8 @@ describe('<MediaPlayer>', () => {
 		describe('first time play', () => {
 			it('click on <CenteredPlayButton /> start playing', async () => {
 				const { getByTestId, mediaStore } = setupMediaPlayer();
-				// wait 1 sec to mount state and load initial data
-				await act(async () => await sleep(1000));
+				// wait 1 ms to mount state and load initial data
+				await act(async () => await sleep(1));
 
 				const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
 				const playbackRateDiv = getByTestId(CENTERED_BOTTOM_PLAYBACK);
@@ -81,8 +85,8 @@ describe('<MediaPlayer>', () => {
 			});
 			it('click on <CenteredBottomPlayback /> do not start playing', async () => {
 				const { getByTestId, mediaStore } = setupMediaPlayer();
-				// wait 1 sec to mount state and load initial data
-				await act(async () => await sleep(1000));
+				// wait 1 ms to mount state and load initial data
+				await act(async () => await sleep(1));
 
 				const playbackRate2Btn = getByTestId(`${CENTERED_BOTTOM_PLAYBACK}-2`);
 
@@ -94,8 +98,8 @@ describe('<MediaPlayer>', () => {
 			});
 			it('click on media-player layout start playing and hide <CenteredPlayButton /> and <CenteredPlayButton /> ', async () => {
 				const { getByTestId, mediaStore } = setupMediaPlayer();
-				// wait 1 sec to mount state and load initial data
-				await act(async () => await sleep(1000));
+				// wait 1 ms to mount state and load initial data
+				await act(async () => await sleep(1));
 
 				const mediaPlayerDiv = getByTestId(REACT_PLAYER);
 				const playbackRateDiv = getByTestId(CENTERED_BOTTOM_PLAYBACK);
@@ -113,8 +117,8 @@ describe('<MediaPlayer>', () => {
 	describe('Play/Pause animation on triggered event', () => {
 		it('play/pause animation on layout click', async () => {
 			const { getByTestId } = setupMediaPlayer();
-			// wait 1 sec to mount state and load initial data
-			await act(async () => await sleep(2000));
+			// wait 1 ms to mount state and load initial data
+			await act(async () => await sleep(1));
 
 			const mediaPlayerDiv = getByTestId(REACT_PLAYER);
 			const playEl = getByTestId(PLAY_ANIMATION);
@@ -139,8 +143,8 @@ describe('<MediaPlayer>', () => {
 		});
 		it('play/pause animation on clicking <PlayPauseReplay />', async () => {
 			const { getByTestId } = setupMediaPlayer();
-			// wait 1 sec to mount state and load initial data
-			await act(async () => await sleep(2000));
+			// wait 1 ms to mount state and load initial data
+			await act(async () => await sleep(1));
 
 			const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
 			const playEl = getByTestId(PLAY_ANIMATION);
@@ -165,11 +169,11 @@ describe('<MediaPlayer>', () => {
 			expect(pauseEl.style.display).toBe('none');
 		});
 	});
-	describe('Hovering player layout', () => {
-		it('<BottomControls /> are not displayed if media has not started', async () => {
+	describe('<BottomControls />: hovering player layout', () => {
+		it('do not display on first time play', async () => {
 			const { getByTestId, queryByTestId } = setupMediaPlayer();
-			// wait 1 sec to mount state and load initial data
-			await act(async () => await sleep(2000));
+			// wait 1 ms to mount state and load initial data
+			await act(async () => await sleep(1));
 
 			const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
 			const bottomButtons = queryByTestId(BOTTOM_CONTROL_BUTTONS);
@@ -177,6 +181,35 @@ describe('<MediaPlayer>', () => {
 
 			await userEvent.click(startBtn);
 			expect(getByTestId(BOTTOM_CONTROL_BUTTONS)).toBeInTheDocument();
+		});
+		it('do not display when leaving <MediaContainer />', async () => {
+			const { getByTestId, queryByTestId } = setupMediaPlayer();
+			// wait 1 ms to mount state and load initial data
+			await act(async () => await sleep(1));
+
+			const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
+
+			await userEvent.click(startBtn);
+			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).toBeInTheDocument();
+
+			await userEvent.unhover(getByTestId(MEDIA_CONTAINER));
+			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).not.toBeInTheDocument();
+		});
+		it(`do not display after ${OVERLAY_HIDE_DELAY}ms on hovered <MediaContainer /> layout`, async () => {
+			const { getByTestId, queryByTestId } = setupMediaPlayer();
+			// wait 1 ms to mount state and load initial data
+			await act(async () => await sleep(1));
+
+			const startBtn = getByTestId(CENTERED_PLAY_BUTTON);
+
+			await userEvent.click(startBtn);
+			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).toBeInTheDocument();
+
+			await userEvent.hover(getByTestId(MEDIA_CONTAINER));
+			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).toBeInTheDocument();
+			// because onMouseEvent is throttled, overlay can be hidden for a +-1sec
+			await act(async () => await sleep(OVERLAY_HIDE_DELAY + 1000));
+			expect(queryByTestId(BOTTOM_CONTROL_BUTTONS)).not.toBeInTheDocument();
 		});
 	});
 });

--- a/src/components/play-pause-animation/PauseAnimation.tsx
+++ b/src/components/play-pause-animation/PauseAnimation.tsx
@@ -2,7 +2,10 @@ import { FC, useEffect, useState } from 'react';
 
 import { useMediaStore } from '../../context';
 import { useIsAudio, useMediaListener } from '../../hooks';
-import { DEFAULT_EVENT_ANIMATION_DURATION } from '../../utils/constants';
+import {
+	DEFAULT_EVENT_ANIMATION_DURATION,
+	PAUSE_ANIMATION,
+} from '../../utils/constants';
 import { AnimatedIconWrapper } from '../animated-icon-wrapper/AnimatedIconWrapper';
 import { BigPauseIcon } from '../icons';
 
@@ -56,6 +59,7 @@ export const PauseAnimation: FC<PauseAnimationProps> = ({
 			durationMs={animationDuration}
 			startAnimation={showPauseAnimation}
 			className={className}
+			data-testid={PAUSE_ANIMATION}
 		>
 			<BigPauseIcon className={centeredIcon} />
 		</AnimatedIconWrapper>

--- a/src/components/play-pause-animation/PlayAnimation.tsx
+++ b/src/components/play-pause-animation/PlayAnimation.tsx
@@ -2,7 +2,10 @@ import { FC, useEffect, useState } from 'react';
 
 import { useMediaStore } from '../../context';
 import { useMediaListener, useIsAudio } from '../../hooks';
-import { DEFAULT_EVENT_ANIMATION_DURATION } from '../../utils/constants';
+import {
+	DEFAULT_EVENT_ANIMATION_DURATION,
+	PLAY_ANIMATION,
+} from '../../utils/constants';
 import { AnimatedIconWrapper } from '../animated-icon-wrapper/AnimatedIconWrapper';
 import { BigPlayIcon } from '../icons';
 
@@ -57,6 +60,7 @@ export const PlayAnimation: FC<PlayAnimationProps> = ({
 			durationMs={animationDuration}
 			startAnimation={showPlayAnimation}
 			className={className}
+			data-testid={PLAY_ANIMATION}
 		>
 			<BigPlayIcon className={centeredIcon} />
 		</AnimatedIconWrapper>

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -2,7 +2,7 @@ import { FC, memo } from 'react';
 import ReactPlayer from 'react-player';
 
 import { useMediaStore } from '../../context';
-import { PROGRESS_INTERVAL } from '../../utils';
+import { PROGRESS_INTERVAL, REACT_PLAYER } from '../../utils';
 
 import { useReactPlayerHook } from './useReactPlayerHook';
 
@@ -28,7 +28,7 @@ export const Player: FC<PlayerProps> = memo(({ url, className }) => {
 			width="100%"
 			height={isFullscreen ? '100%' : 'unset'}
 			className={className}
-			data-testid="media-player"
+			data-testid={REACT_PLAYER}
 			config={{
 				file: {
 					attributes: {

--- a/src/components/progress-bar/ProgressBar.tsx
+++ b/src/components/progress-bar/ProgressBar.tsx
@@ -4,7 +4,7 @@ import { FC, useState } from 'react';
 import { useMediaStore } from '../../context';
 import { useMediaListener } from '../../hooks';
 import { useIsAudio } from '../../hooks/use-is-audio';
-import { PROGRESS_BAR_DIVIDER } from '../../utils/constants';
+import { PROGRESS_BAR, PROGRESS_BAR_DIVIDER } from '../../utils/constants';
 import { toTwoDigits } from '../../utils/number';
 
 import { ProgressBarStyled } from './components/ProgressBarStyled';
@@ -13,13 +13,18 @@ import { useProgressBarStyles } from './useProgressBarStyles';
 
 interface ProgressBarProps extends SliderProps {
 	className?: string;
+	'data-testid'?: string;
 }
 
 /** A MUI Slider configured for displaying currentTime/duration values from `MediaStore`
  * @category React Component
  * @category UI Controls
  */
-export const ProgressBar: FC<ProgressBarProps> = ({ className, ...props }) => {
+export const ProgressBar: FC<ProgressBarProps> = ({
+	className,
+	'data-testid': dataTestId = PROGRESS_BAR,
+	...props
+}) => {
 	const isAudio = useIsAudio();
 	const [value, setValue] = useState(0);
 	const hasStarted = useMediaStore(state => state.hasPlayedOrSeeked);
@@ -73,6 +78,7 @@ export const ProgressBar: FC<ProgressBarProps> = ({ className, ...props }) => {
 			onChange={onCurrentTimeUpdate}
 			value={value}
 			components={{ Rail }}
+			data-testid={dataTestId}
 			{...props}
 		/>
 	);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -47,3 +47,7 @@ export const BOTTOM_CONTROL_BUTTONS = 'BOTTOM_CONTROL_BUTTONS';
 export const MEDIA_CONTAINER = 'MEDIA_CONTAINER';
 /** Constant data-testid for <PictureInPictureButton/> */
 export const PIP_BUTTON = 'PIP_BUTTON';
+/** Constant data-testid for <ProgressBar/> */
+export const PROGRESS_BAR = 'PROGRESS_BAR';
+/** Constant data-testid for <DraggablePopover/> */
+export const DRAGGABLE_POPOVER = 'DRAGGABLE_POPOVER';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,7 +20,22 @@ export const PROGRESS_INTERVAL = 50;
 /** Seconds that should be skipped when using Forward/Rewind  buttons */
 export const SECONDS_TO_SKIP = 10;
 
-/** Constant for data-testid for `<CenteredPlayButton />` */
+// Constants for testing
+/** Constant data-testid for `<CenteredPlayButton />` */
 export const CENTERED_PLAY_BUTTON = 'CENTERED_PLAY_BUTTON';
-/** Constant for data-testid for `<CenteredBottomPlayback />` */
+/** Constant data-testid for `<CenteredBottomPlayback />` */
 export const CENTERED_BOTTOM_PLAYBACK = 'CENTERED_BOTTOM_PLAYBACK';
+/** Constant data-testid for `ReactPlayer` */
+export const REACT_PLAYER = 'REACT_PLAYER';
+/** Constant data-testid for <PlayAnimation/> */
+export const PLAY_ANIMATION = 'PLAY_ANIMATION';
+/** Constant data-testid for <PauseAnimation/> */
+export const PAUSE_ANIMATION = 'PAUSE_ANIMATION';
+/** Constant data-testid for <PlayPauseReplay/> */
+export const PLAY_PAUSE_REPLAY = 'PLAY_PAUSE_REPLAY';
+/** Constant data-testid for <Replay/> Icon */
+export const REPLAY_ICON = 'REPLAY_ICON';
+/** Constant data-testid for <Pause/> Icon */
+export const PAUSE_ICON = 'PAUSE_ICON';
+/** Constant data-testid for <Play/> Icon */
+export const PLAY_ICON = 'PLAY_ICON';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -39,3 +39,9 @@ export const REPLAY_ICON = 'REPLAY_ICON';
 export const PAUSE_ICON = 'PAUSE_ICON';
 /** Constant data-testid for <Play/> Icon */
 export const PLAY_ICON = 'PLAY_ICON';
+/** Constant data-testid for <Controls/> */
+export const CONTROLS = 'CONTROLS';
+/** Constant data-testid for <BottomControlButtons/> */
+export const BOTTOM_CONTROL_BUTTONS = 'BOTTOM_CONTROL_BUTTONS';
+/** Constant data-testid for <MediaContainer/> */
+export const MEDIA_CONTAINER = 'MEDIA_CONTAINER';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -51,3 +51,5 @@ export const PIP_BUTTON = 'PIP_BUTTON';
 export const PROGRESS_BAR = 'PROGRESS_BAR';
 /** Constant data-testid for <DraggablePopover/> */
 export const DRAGGABLE_POPOVER = 'DRAGGABLE_POPOVER';
+/** Constant data-testid for <FullscreenButton/> */
+export const FULLSCREEN_BUTTON = 'FULLSCREEN_BUTTON';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -45,3 +45,5 @@ export const CONTROLS = 'CONTROLS';
 export const BOTTOM_CONTROL_BUTTONS = 'BOTTOM_CONTROL_BUTTONS';
 /** Constant data-testid for <MediaContainer/> */
 export const MEDIA_CONTAINER = 'MEDIA_CONTAINER';
+/** Constant data-testid for <PictureInPictureButton/> */
+export const PIP_BUTTON = 'PIP_BUTTON';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -19,3 +19,8 @@ export const PROGRESS_INTERVAL = 50;
 
 /** Seconds that should be skipped when using Forward/Rewind  buttons */
 export const SECONDS_TO_SKIP = 10;
+
+/** Constant for data-testid for `<CenteredPlayButton />` */
+export const CENTERED_PLAY_BUTTON = 'CENTERED_PLAY_BUTTON';
+/** Constant for data-testid for `<CenteredBottomPlayback />` */
+export const CENTERED_BOTTOM_PLAYBACK = 'CENTERED_BOTTOM_PLAYBACK';


### PR DESCRIPTION
As a part of Integration tests: https://github.com/Collaborne/backlog/issues/1326
- [x] Tests for first time playing (first click on ready/mounted `<MediaPlayer>`)
- [x] Test on Play/Pause Animations
- [x] Tests for `<Controls/>` and hovering effects(_Also `<BottomControlsButtons/>` - add missing parts_)
- [x] Tests on PIP 
- [x] Tests on FullscreenApi
- [x] Add verbose script for coverage (`npm run test:coverage`)