### PR TITLE
Fix PIP resizing bug styling and keep PIP mode always on screen

### DIFF
--- a/.storybook/stories/0-MediaPlayer.stories.tsx
+++ b/.storybook/stories/0-MediaPlayer.stories.tsx
@@ -7,7 +7,11 @@ import {
 import { withDemoCard, withIntl } from '../decorators';
 
 export const MediaPlayer: Story<MediaPlayerProps> = args => {
-	return <MediaPlayerComponent {...args} />;
+	return (
+		<div style={{ height: '6000px' }}>
+			<MediaPlayerComponent {...args} />
+		</div>
+	);
 };
 
 export default {

--- a/src/components/bottom-control-buttons/components/PictureInPictureButton.tsx
+++ b/src/components/bottom-control-buttons/components/PictureInPictureButton.tsx
@@ -24,13 +24,19 @@ export const PictureInPictureButton: FC<PictureInPictureButtonProps> = ({
 	...props
 }) => {
 	const { onMouseEnter, onMouseLeave } = useOnHoveredControlElement();
-	const [isPip, exitPip, requestPip] = useMediaStore(
-		state => [state.isPip, state.exitPip, state.requestPip],
+	const [isPip, exitPip, requestPip, setHasPipTriggeredByClick] = useMediaStore(
+		state => [
+			state.isPip,
+			state.exitPip,
+			state.requestPip,
+			state.setHasPipTriggeredByClick,
+		],
 		shallow,
 	);
 
 	const togglePip = () => {
 		if (isPip) {
+			setHasPipTriggeredByClick(true);
 			return exitPip();
 		}
 		return requestPip();

--- a/src/components/core-player/CorePlayer.tsx
+++ b/src/components/core-player/CorePlayer.tsx
@@ -6,7 +6,6 @@ import {
 } from '@mui/material/styles';
 import { deepmerge } from '@mui/utils';
 import { FC, ReactNode } from 'react';
-import { useScrollbarWidth } from 'react-use';
 
 import { MediaProvider } from '../../context/MediaProvider';
 import { PIPContextProvider } from '../../context/PIPControlsProvider';
@@ -21,8 +20,8 @@ import { ExternalStateUpdater } from './components/ExternalStateUpdater';
 import { CorePlayerInitialState, PROVIDER_INITIAL_STATE } from './types';
 import { useCorePlayerHook } from './useCorePlayerHook';
 
-/** In case if width is not provided for browsers scrollbar, this constant will be used */
-const SCROLLBAR_WIDTH = 16;
+/** Default positioning on X and Y axis of PIP player */
+const DEFAULT_AXIS_DISTANCE = 16;
 
 export interface CorePlayerProps {
 	/** The url of the media file to be played */
@@ -83,7 +82,6 @@ export const CorePlayer: FC<CorePlayerProps> = ({
 	const nestedThemes = deepmerge(createPlayerTheme(), theme || {});
 	const { classes, cx } = useFilePlayerStyles({ isAudio });
 	const classNames = cx(classes.wrapper, className);
-	const scrollbarWidth = useScrollbarWidth();
 
 	return (
 		<ThemeProvider theme={nestedThemes}>
@@ -108,8 +106,8 @@ export const CorePlayer: FC<CorePlayerProps> = ({
 							className={classNames}
 							url={url}
 							audioPlaceholder={audioPlaceholder}
-							xAxisDistance={xAxisDistance ?? scrollbarWidth ?? SCROLLBAR_WIDTH}
-							yAxisDistance={yAxisDistance ?? scrollbarWidth ?? SCROLLBAR_WIDTH}
+							xAxisDistance={xAxisDistance ?? DEFAULT_AXIS_DISTANCE}
+							yAxisDistance={yAxisDistance ?? DEFAULT_AXIS_DISTANCE}
 							reactPlayerClassName={reactPlayerClassName}
 						>
 							{children}

--- a/src/components/draggable-popover/DraggablePopover.tsx
+++ b/src/components/draggable-popover/DraggablePopover.tsx
@@ -48,7 +48,7 @@ export const DraggablePopover: FC<DraggablePopoverProps> = memo(
 		const { PIPControls } = usePipControlsContext();
 		const isAudio = useIsAudio();
 		const isPip = useMediaStore(state => state.isPip);
-		const { defaultPosition, defaultWidth, enableResizing } =
+		const { dimensions, enableResizing, handleDragStop, handleResizeStop } =
 			useDraggablePopoverHook({
 				disablePortal: props.disablePortal,
 				xAxisDistance,
@@ -71,10 +71,6 @@ export const DraggablePopover: FC<DraggablePopoverProps> = memo(
 				<div className={portalWrapper} data-testid={dataTestId}>
 					<Rnd
 						bounds="parent"
-						default={{
-							...defaultPosition,
-							...defaultWidth,
-						}}
 						disableDragging={props.disablePortal}
 						enableResizing={enableResizing}
 						lockAspectRatio
@@ -88,6 +84,10 @@ export const DraggablePopover: FC<DraggablePopoverProps> = memo(
 						{...rndProps}
 						minWidth={241}
 						minHeight={146}
+						onDragStop={handleDragStop}
+						onResizeStop={handleResizeStop}
+						size={{ height: dimensions.height, width: dimensions.width }}
+						position={{ x: dimensions.x, y: dimensions.y }}
 					>
 						<Paper
 							elevation={0}

--- a/src/components/draggable-popover/useDraggablePopoverHook.ts
+++ b/src/components/draggable-popover/useDraggablePopoverHook.ts
@@ -1,4 +1,11 @@
-import { Position, ResizeEnable } from 'react-rnd';
+import { useEffect, useState } from 'react';
+import {
+	Position,
+	ResizeEnable,
+	RndDragCallback,
+	RndResizeCallback,
+} from 'react-rnd';
+import { usePrevious, useScrollbarWidth } from 'react-use';
 import useWindowSize from 'react-use/lib/useWindowSize';
 
 import { DEFAULT_PIP_SIZE } from '../../utils/constants';
@@ -13,17 +20,28 @@ interface UseDraggablePopoverHookProps
 	disablePortal?: boolean;
 }
 
+type Dimensions = Size & Position;
 interface UseDraggablePopoverHook {
 	/** Default player size */
-	defaultWidth: Size;
-	/** Default positioning on layout */
-	defaultPosition: Position;
-	/** "Corners"  where we allow to start resizing */
+	dimensions: Dimensions;
 	enableResizing: ResizeEnable;
+	handleDragStop: RndDragCallback;
+	handleResizeStop: RndResizeCallback;
 }
 
 const vw = window.innerWidth;
 const vh = window.innerHeight;
+
+/** In case if width is not provided for browsers scrollbar, this constant will be used */
+const SCROLLBAR_WIDTH = 16;
+
+const DEFAULT_DIMENSIONS: Dimensions = {
+	width: '100%',
+	height: '100%',
+	y: 0,
+	x: 0,
+};
+
 export const useDraggablePopoverHook = ({
 	disablePortal,
 	xAxisDistance,
@@ -31,25 +49,48 @@ export const useDraggablePopoverHook = ({
 }: UseDraggablePopoverHookProps): UseDraggablePopoverHook => {
 	// DraggablePopover DnD params:
 	const windowSize = useWindowSize();
+	const prevWindowSize = usePrevious(windowSize);
+	const scrollbarWidth = useScrollbarWidth() ?? SCROLLBAR_WIDTH;
 
-	const defaultWidth = disablePortal
-		? { width: '100%', height: '100%' }
-		: { ...DEFAULT_PIP_SIZE };
+	// Get player width + margin on 2 sides
+	const pipPlayerWidth =
+		DEFAULT_PIP_SIZE.width + xAxisDistance + scrollbarWidth;
+	const pipPlayerHight =
+		DEFAULT_PIP_SIZE.height + yAxisDistance + scrollbarWidth;
 
-	const defaultPosition = (() => {
-		if (disablePortal) {
-			return { x: 0, y: 0 };
+	const [dimensions, setDimensions] = useState<Dimensions>(DEFAULT_DIMENSIONS);
+
+	useEffect(() => {
+		if (!disablePortal) {
+			return setDimensions({
+				width: DEFAULT_PIP_SIZE.width,
+				height: DEFAULT_PIP_SIZE.height,
+				y: (windowSize?.height || vh) - pipPlayerHight,
+				x: (windowSize?.width || vw) - pipPlayerWidth,
+			});
 		}
 
-		// Get player width + margin on 2 sides
-		const pipPlayerWidth = DEFAULT_PIP_SIZE.width + xAxisDistance * 2;
-		const pipPlayerHight = DEFAULT_PIP_SIZE.height + yAxisDistance * 2;
+		setDimensions(DEFAULT_DIMENSIONS);
+		// should occur only on switching PIP mode(isPip=disablePortal)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [disablePortal]);
 
-		return {
-			y: (windowSize?.height || vh) - pipPlayerHight,
-			x: (windowSize?.width || vw) - pipPlayerWidth,
-		};
-	})();
+	useEffect(() => {
+		if (!disablePortal) {
+			setDimensions(prev => {
+				const newX =
+					prev.x +
+					windowSize.width -
+					(prevWindowSize?.width ?? windowSize.width);
+				return {
+					...prev,
+					x: newX > 0 ? newX : 0,
+				};
+			});
+		}
+		// Should occur only in PIP mode and when is browser resized(windowSize changed)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [windowSize, disablePortal]);
 
 	const enableResizing = disablePortal
 		? false
@@ -59,9 +100,28 @@ export const useDraggablePopoverHook = ({
 				bottomLeft: true,
 				bottomRight: true,
 		  };
+
+	const handleDragStop: RndDragCallback = (_e, d) => {
+		setDimensions(prev => ({ ...prev, x: d.x, y: d.y }));
+	};
+	const handleResizeStop: RndResizeCallback = (
+		_e,
+		_direction,
+		ref,
+		_delta,
+		position,
+	) => {
+		setDimensions(prev => ({
+			...prev,
+			width: ref.style.width,
+			height: ref.style.height,
+			...position,
+		}));
+	};
 	return {
-		defaultPosition,
-		defaultWidth,
 		enableResizing,
+		dimensions,
+		handleDragStop,
+		handleResizeStop,
 	};
 };

--- a/src/components/media-container/MediaContainer.tsx
+++ b/src/components/media-container/MediaContainer.tsx
@@ -55,7 +55,7 @@ export const MediaContainer: FC<MediaContainerProps> = memo(
 		});
 
 		const { isPlayerReady } = useIsPlayerReadyHook({ url });
-		const { containerSizeRef } = usePipHook({ isPlayerReady });
+		usePipHook({ isPlayerReady });
 		const { onMouseEnter, onMouseLeave, onMouseMove } = useMouseActivityHook();
 
 		const reactClassNames = cx(reactPlayer, reactPlayerClassName);
@@ -83,10 +83,7 @@ export const MediaContainer: FC<MediaContainerProps> = memo(
 					<Player url={url} className={reactClassNames} />
 				</DraggablePopover>
 				{isPip && !isAudio && (
-					<MediaPoster
-						width={containerSizeRef?.current?.width || 0}
-						height={containerSizeRef?.current?.height || 0}
-					>
+					<MediaPoster width="100%" height="100%">
 						<div className={pipText}>{intl.get('media.playing_pip')}</div>
 					</MediaPoster>
 				)}

--- a/src/components/media-container/usePipHook.ts
+++ b/src/components/media-container/usePipHook.ts
@@ -6,15 +6,11 @@ import shallow from 'zustand/shallow';
 import { useMediaStore } from '../../context/MediaProvider';
 import { useMediaListener } from '../../hooks/use-media-listener';
 import { PROGRESS_INTERVAL } from '../../utils/constants';
-import { getElementOffset } from '../../utils/html-elements';
-import { ContainerSizePosition } from '../draggable-popover/DraggablePopover';
 
 interface UsePipHookProps {
 	isPlayerReady: boolean;
 }
-interface UsePipHook {
-	containerSizeRef: React.MutableRefObject<ContainerSizePosition | undefined>;
-}
+interface UsePipHook {}
 
 /** Defines root margin when scrolling to bottom */
 const BOTTOM_ROOT_MARGIN = '48px';
@@ -70,21 +66,6 @@ export const usePipHook = ({ isPlayerReady }: UsePipHookProps): UsePipHook => {
 	const entryBottom = useIntersection(mediaContainerRef, {});
 	const isVisibleFromScrollingBottom = Boolean(entryBottom?.isIntersecting);
 
-	const containerSizeRef = useRef<ContainerSizePosition>();
-
-	const calculateContainerSizes = useCallback(() => {
-		const width = mediaContainerRef?.current?.offsetWidth;
-		const height = mediaContainerRef?.current?.offsetHeight;
-		const rect = mediaContainerRef?.current
-			? getElementOffset(mediaContainerRef.current)
-			: undefined;
-		if (width && height && rect) {
-			containerSizeRef.current = { width, height, ...rect };
-		}
-		// Calculates only on mounting the MediaContainer and passes this size to <MediaPoster/>
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
-
 	// On wheel event - updating that pip isn't triggered by a click on pip icon button
 	// In this way we can evite overlapping of wheel vs click onPip
 	const onWheel = useCallback(() => {
@@ -139,7 +120,6 @@ export const usePipHook = ({ isPlayerReady }: UsePipHookProps): UsePipHook => {
 	useMediaListener(
 		'pipEnter',
 		() => {
-			calculateContainerSizes();
 			setTimeout(() => {
 				setCurrentTime?.(currentTimeRef.current);
 			}, PROGRESS_INTERVAL - 1);
@@ -157,5 +137,5 @@ export const usePipHook = ({ isPlayerReady }: UsePipHookProps): UsePipHook => {
 		listener,
 	);
 
-	return { containerSizeRef };
+	return {};
 };

--- a/src/components/media-container/usePipHook.ts
+++ b/src/components/media-container/usePipHook.ts
@@ -69,10 +69,9 @@ export const usePipHook = ({ isPlayerReady }: UsePipHookProps): UsePipHook => {
 	// On wheel event - updating that pip isn't triggered by a click on pip icon button
 	// In this way we can evite overlapping of wheel vs click onPip
 	const onWheel = useCallback(() => {
-		if (!isVisibleFromScrollingBottom || !isVisibleFromScrollingTop) {
-			return setHasPipTriggeredByClick(false);
-		}
-		setHasPipTriggeredByClick(true);
+		const isInsideScrollingArea =
+			isVisibleFromScrollingBottom && isVisibleFromScrollingTop;
+		setHasPipTriggeredByClick(isInsideScrollingArea);
 	}, [
 		isVisibleFromScrollingBottom,
 		isVisibleFromScrollingTop,

--- a/src/components/media-container/usePipHook.ts
+++ b/src/components/media-container/usePipHook.ts
@@ -70,8 +70,9 @@ export const usePipHook = ({ isPlayerReady }: UsePipHookProps): UsePipHook => {
 	// In this way we can evite overlapping of wheel vs click onPip
 	const onWheel = useCallback(() => {
 		if (!isVisibleFromScrollingBottom || !isVisibleFromScrollingTop) {
-			setHasPipTriggeredByClick(false);
+			return setHasPipTriggeredByClick(false);
 		}
+		setHasPipTriggeredByClick(true);
 	}, [
 		isVisibleFromScrollingBottom,
 		isVisibleFromScrollingTop,

--- a/src/utils/html-elements.ts
+++ b/src/utils/html-elements.ts
@@ -1,7 +1,0 @@
-export const getElementOffset = (el: HTMLElement | null) => {
-	const rect = el?.getBoundingClientRect();
-	return {
-		left: (rect?.left || 0) + window.scrollX,
-		top: (rect?.top || 0) + window.scrollY,
-	};
-};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,7 +2,6 @@ export * from './array';
 export * from './colors';
 export * from './constants';
 export * from './highlights';
-export * from './html-elements';
 export * from './is-url-supported';
 export * from './media-utils';
 export * from './MultiplySymbol';


### PR DESCRIPTION
- ### Keep always PIP player on screen when resizing window
Screen Recording: 


https://user-images.githubusercontent.com/50721739/203644857-d5dfede8-f115-4c6c-a499-22381884196b.mp4



-  ### Bug with resizing on PIP mode
 #### Reproduction case
 1. Play a video
 2. Enter PIP mode
 3. Resize window
 
Screen Recording: 
 

https://user-images.githubusercontent.com/50721739/203644962-dee94b8e-e96b-403b-ba38-7dbd407ee583.mp4

- ### Activate PIP from scroll, return into view and press PIP button is failed
 #### Reproduction case
 1. Play a video in a container that can be scrolled
 2. scroll down to be PIP mode appeared
 3. scroll up to main player(pip dissapears)
 4. press on PIP button
 
 Screen Recording:
 

https://user-images.githubusercontent.com/50721739/203708696-97435eea-a1f0-49a5-a3d5-ad7760b6e742.mp4


 