### PR TITLE
Remove wheel event from the PIP "callers"

### DIFF
--- a/src/components/draggable-popover/DraggablePopover.tsx
+++ b/src/components/draggable-popover/DraggablePopover.tsx
@@ -73,7 +73,7 @@ export const DraggablePopover: FC<DraggablePopoverProps> = memo(
 			usePipMouseActivityHook();
 
 		const {
-			classes: { paper, portalWrapper, resizeSquares },
+			classes: { paper, portalWrapper, resizeSquares, paperPositioning },
 			cx,
 		} = useDraggablePopoverStyles({
 			isExpanded: Boolean(props.disablePortal),
@@ -90,50 +90,50 @@ export const DraggablePopover: FC<DraggablePopoverProps> = memo(
 						isElement(el) && el !== null && portalWrapperRef(el);
 					}}
 				>
-					{!isPipPositioning && (
-						<Rnd
-							bounds="parent"
-							disableDragging={props.disablePortal}
-							enableResizing={enableResizing}
-							lockAspectRatio
-							allowAnyClick
-							resizeHandleClasses={{
-								topLeft: resizeSquares,
-								topRight: resizeSquares,
-								bottomLeft: resizeSquares,
-								bottomRight: resizeSquares,
-							}}
-							{...rndProps}
-							minWidth={241}
-							minHeight={146}
-							onDragStop={handleDragStop}
-							onResizeStop={handleResizeStop}
-							size={{ height: dimensions.height, width: dimensions.width }}
-							position={{ x: dimensions.x, y: dimensions.y }}
+					<Rnd
+						bounds="parent"
+						disableDragging={props.disablePortal}
+						enableResizing={enableResizing}
+						lockAspectRatio
+						allowAnyClick
+						resizeHandleClasses={{
+							topLeft: resizeSquares,
+							topRight: resizeSquares,
+							bottomLeft: resizeSquares,
+							bottomRight: resizeSquares,
+						}}
+						{...rndProps}
+						minWidth={241}
+						minHeight={146}
+						onDragStop={handleDragStop}
+						onResizeStop={handleResizeStop}
+						size={{ height: dimensions.height, width: dimensions.width }}
+						position={{ x: dimensions.x, y: dimensions.y }}
+					>
+						<Paper
+							elevation={0}
+							className={cx(paper, className, {
+								[paperPositioning]: isPipPositioning,
+							})}
+							onMouseMove={onMouseMove}
+							onMouseLeave={onMouseLeave}
+							onMouseEnter={onMouseEnter}
 						>
-							<Paper
-								elevation={0}
-								className={cx(paper, className)}
-								onMouseMove={onMouseMove}
-								onMouseLeave={onMouseLeave}
-								onMouseEnter={onMouseEnter}
-							>
-								{children}
-								{!props.disablePortal && (
-									<>
-										{isAudio && (
-											<MediaPoster
-												img={audioPlaceholder}
-												width="100%"
-												height="100%"
-											/>
-										)}
-										<PIPControls />
-									</>
-								)}
-							</Paper>
-						</Rnd>
-					)}
+							{children}
+							{!props.disablePortal && (
+								<>
+									{isAudio && (
+										<MediaPoster
+											img={audioPlaceholder}
+											width="100%"
+											height="100%"
+										/>
+									)}
+									<PIPControls />
+								</>
+							)}
+						</Paper>
+					</Rnd>
 				</div>
 			</Portal>
 		);

--- a/src/components/draggable-popover/useDraggablePopoverStyles.ts
+++ b/src/components/draggable-popover/useDraggablePopoverStyles.ts
@@ -30,6 +30,9 @@ export const useDraggablePopoverStyles =
 						borderRadius: theme.spacing(0.5),
 					}),
 			},
+			paperPositioning: {
+				display: 'none',
+			},
 			portalWrapper: {
 				height: isExpanded ? '100%' : `calc(100% - ${theme.spacing(4)})`,
 				width: isExpanded ? '100%' : `calc(100% - ${theme.spacing(4)})`,

--- a/src/components/media-container/usePipHook.ts
+++ b/src/components/media-container/usePipHook.ts
@@ -55,12 +55,14 @@ export const usePipHook = ({ isPlayerReady }: UsePipHookProps): UsePipHook => {
 		threshold: 0.1,
 	});
 
-	const isVisible = Boolean(intersectionObservable?.isIntersecting);
+	const isVisible = intersectionObservable?.isIntersecting;
 
 	// If we have called PIP events via click, refresh hasPipTriggeredByClick
 	// eg: triggering PIP by click, being in viewport wont overlap events
 	useEffect(() => {
-		setHasPipTriggeredByClick(isVisible);
+		if (isVisible !== undefined) {
+			setHasPipTriggeredByClick(isVisible);
+		}
 	}, [isVisible, setHasPipTriggeredByClick]);
 
 	// If the player is mounted, ready and isPlaying then display/hide pip player


### PR DESCRIPTION
- Trigger PIP mode if player is not in the viewport (no more dependencies on wheel event)
- fix time losing between switching modes

**NOTE: Everytime when PIP mode goes on/off we remount the `<Player/>` component[children of [DraggablePopover](https://github.com/Collaborne/media-player/blob/e19f66cb5b1b286e9c4e340682c6ee7a65ba16c7/src/components/draggable-popover/DraggablePopover.tsx#L85)] (because of portal), and this causes losing time of the player (prop [onProgress](https://github.com/Collaborne/media-player/blob/e19f66cb5b1b286e9c4e340682c6ee7a65ba16c7/src/components/player/useReactPlayerHook.ts#L78) is created with 0 playedSeconds on every mount), and this is the reason why we need to use timeouts in [usePipHook](https://github.com/Collaborne/media-player/blob/e19f66cb5b1b286e9c4e340682c6ee7a65ba16c7/src/components/media-container/usePipHook.ts#L123-L125)**