### PR TITLE
Add unsplash image insetad of random picsum photo

### DIFF
--- a/.storybook/decorators/with-media-wrapper.tsx
+++ b/.storybook/decorators/with-media-wrapper.tsx
@@ -11,7 +11,8 @@ const WrappedStyled = styled(Paper)(({ theme }) => ({
 	borderRadius: `${theme.shape.borderRadius} ${theme.shape.borderRadius} 0 0`,
 	borderColor: theme.palette.grey[500],
 	overflow: 'hidden',
-	backgroundImage: 'url("https://picsum.photos/640/480")',
+	backgroundImage:
+		'url("https://images.unsplash.com/photo-1533827432537-70133748f5c8")',
 	position: 'relative',
 }));
 /**

--- a/.storybook/stories/13-CustomizedAudioPlayer.stories.tsx
+++ b/.storybook/stories/13-CustomizedAudioPlayer.stories.tsx
@@ -37,7 +37,7 @@ export const Customized: Story<CorePlayerProps> = args => {
 		<CorePlayer className={dimension} {...args}>
 			<div className={placeholder}>
 				<MediaPoster
-					img="https://picsum.photos/300/200"
+					img="https://images.unsplash.com/photo-1533827432537-70133748f5c8"
 					width="100%"
 					height="100%"
 				/>


### PR DESCRIPTION
- Add same picture for stories, to avoid chromatic detecting UI changes, when no changes was made to the UI

Ex: chromatic always see random images as a change:
![Screenshot from 2023-02-07 15-30-03](https://user-images.githubusercontent.com/50721739/217254068-5bf5de48-c562-4840-870d-73d6b03275e6.png)
 