### PR TITLE
Remove PIP button for media player when pip state is disabled

### DIFF
--- a/src/components/media-player/MediaPlayer.tsx
+++ b/src/components/media-player/MediaPlayer.tsx
@@ -74,7 +74,7 @@ export const MediaPlayer: FC<MediaPlayerProps> = memo(
 							</Grid>
 							<Grid item className={gridCentered} xs justifyContent="flex-end">
 								<PlaybackRateButton />
-								<PictureInPictureButton />
+								{corePlayerProps.isPipEnabled && <PictureInPictureButton />}
 								<FullscreenButton />
 							</Grid>
 						</BottomControlButtons>

--- a/src/components/media-player/MediaPlayer.tsx
+++ b/src/components/media-player/MediaPlayer.tsx
@@ -37,11 +37,11 @@ export interface MediaPlayerProps extends Omit<CorePlayerProps, 'children'> {
  * @category Player
  */
 export const MediaPlayer: FC<MediaPlayerProps> = memo(
-	({ children, ...corePlayerProps }) => {
+	({ children, isPipEnabled = true, ...corePlayerProps }) => {
 		const { gridCentered } = useMediaPlayerStyles().classes;
 		const { controls } = useControlsStyles().classes;
 		return (
-			<CorePlayer {...corePlayerProps}>
+			<CorePlayer isPipEnabled={isPipEnabled} {...corePlayerProps}>
 				<Grid className={controls}>
 					<CenteredPlayButton />
 					<CenteredBottomPlayback />
@@ -74,7 +74,7 @@ export const MediaPlayer: FC<MediaPlayerProps> = memo(
 							</Grid>
 							<Grid item className={gridCentered} xs justifyContent="flex-end">
 								<PlaybackRateButton />
-								{corePlayerProps.isPipEnabled && <PictureInPictureButton />}
+								{isPipEnabled && <PictureInPictureButton />}
 								<FullscreenButton />
 							</Grid>
 						</BottomControlButtons>


### PR DESCRIPTION
As `MediaPlayer` is de facto player in many instances, and when pip is disabled, we shall hide it from controls