### PR TITLE
Add `autoPlay` initial prop

### DIFF
--- a/.storybook/stories/14-InitialState.stories.tsx
+++ b/.storybook/stories/14-InitialState.stories.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import {
+	BottomControls,
+	CORE_PLAYER_INITIAL_STATE,
+	CorePlayer,
+	CorePlayerProps,
+	PictureInPictureButton,
+	PlayPauseReplay,
+} from '../../src/components';
+import { useBottomControlButtonsStyles } from '../../src/components/bottom-control-buttons/useBottomControlButtonsStyles';
+import { useControlsStyles } from '../../src/components/controls/useControlsStyles';
+import { CustomPipControls } from '../components/custom-pip-controls/CustomPipControls';
+import { withDemoCard } from '../decorators';
+import { Story } from '../utils/doc';
+
+const Template: Story<Pick<CorePlayerProps, 'initialState'>> = args => {
+	const { controls } = useControlsStyles().classes;
+	const { wrapper } = useBottomControlButtonsStyles().classes;
+	return (
+		<CorePlayer
+			url="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4"
+			PIPControls={CustomPipControls}
+			initialState={args.initialState}
+		>
+			<div className={controls}>
+				<BottomControls>
+					<div className={wrapper}>
+						<PlayPauseReplay svgClassName="medium" />
+						<PictureInPictureButton />
+					</div>
+				</BottomControls>
+			</div>
+		</CorePlayer>
+	);
+};
+
+export default {
+	title: 'CorePlayer',
+	component: CorePlayer,
+	decorators: [withDemoCard],
+	parameters: {
+		controls: { expanded: true },
+	},
+};
+
+export const InitialState: Story<CorePlayerProps> = Template.bind({});
+InitialState.args = {
+	initialState: {
+		...CORE_PLAYER_INITIAL_STATE,
+		isPlaying: true,
+	},
+};
+
+InitialState.argTypes = {
+	initialState: {
+		name: 'props.initialState',
+		description: 'Initial state to configure CorePlayer',
+		table: {
+			type: { summary: 'CorePlayerInitialState' },
+			defaultValue: { summary: JSON.stringify(CORE_PLAYER_INITIAL_STATE) },
+		},
+	},
+};

--- a/.storybook/stories/14-InitialState.stories.tsx
+++ b/.storybook/stories/14-InitialState.stories.tsx
@@ -48,7 +48,7 @@ export const InitialState: Story<CorePlayerProps> = Template.bind({});
 InitialState.args = {
 	initialState: {
 		...CORE_PLAYER_INITIAL_STATE,
-		isPlaying: true,
+		autoPlay: true,
 	},
 };
 

--- a/.storybook/stories/14-InitialState.stories.tsx
+++ b/.storybook/stories/14-InitialState.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
 	BottomControls,
 	CORE_PLAYER_INITIAL_STATE,

--- a/.storybook/utils/doc.ts
+++ b/.storybook/utils/doc.ts
@@ -1,0 +1,31 @@
+import { Annotations, BaseStory } from '@storybook/addons';
+
+type OptionalStoryInterface<Args, ReturnType> = Annotations<
+	Args,
+	ReturnType
+> & {
+	storyName?: string;
+};
+export type Story<Args = unknown, ReturnType = unknown> = BaseStory<
+	Args,
+	ReturnType
+> &
+	OptionalStoryInterface<Args, ReturnType>;
+
+export function withDescription<A, R>(
+	storyDescription: string,
+	story: Story<A, R>,
+): Story<A, R> {
+	story.parameters = {
+		...story.parameters,
+		docs: {
+			...story.parameters?.docs,
+			description: {
+				...story.parameters?.docs?.description,
+				story: storyDescription,
+			},
+		},
+	};
+
+	return story;
+}

--- a/src/components/core-player/types.ts
+++ b/src/components/core-player/types.ts
@@ -1,24 +1,12 @@
-import { Highlight } from '../../types';
-
-/** MediaStore initialization state */
+/**
+ * MediaStore initialization state.
+ * These values are added only on `MediaStore` was initialized, further updates wont be triggered.
+ * */
 export interface CorePlayerInitialState {
-	isPlaying: boolean;
-	/** Initial start time in seconds */
-	startTime: number;
-	/** Initial time for pausing in seconds */
-	endTime: number;
-	/** Media total time(duration) in seconds */
-	duration: number;
-	/** Current played time in seconds */
-	currentTime: number;
-	highlights: Highlight[];
+	/** Autoplay state. Forwarded to ReactPlayer */
+	autoPlay: boolean;
 }
 
 export const CORE_PLAYER_INITIAL_STATE: CorePlayerInitialState = {
-	isPlaying: false,
-	startTime: 0,
-	endTime: 0,
-	duration: 0,
-	currentTime: 0,
-	highlights: [],
+	autoPlay: false,
 };

--- a/src/components/core-player/types.ts
+++ b/src/components/core-player/types.ts
@@ -1,6 +1,6 @@
 /**
  * MediaStore initialization state.
- * These values are added only on `MediaStore` was initialized, further updates wont be triggered.
+ * These values are added only when `MediaStore` was initialized, further updates wont be triggered.
  * */
 export interface CorePlayerInitialState {
 	/** Autoplay state. Forwarded to ReactPlayer */

--- a/src/components/media-container/useReactPlayerProps.ts
+++ b/src/components/media-container/useReactPlayerProps.ts
@@ -18,8 +18,8 @@ export const useReactPlayerProps = (): UseReactPlayerProps => {
 
 	const [
 		reactPlayerRef,
-		initialState,
 		playbackRate,
+		autoPlay,
 		isPlaying,
 		isMuted,
 		volume,
@@ -34,8 +34,8 @@ export const useReactPlayerProps = (): UseReactPlayerProps => {
 	] = useMediaStore(
 		state => [
 			state.reactPlayerRef,
-			state.initialState,
 			state.playbackRate,
+			state.autoPlay,
 			state.isPlaying,
 			state.isMuted,
 			state.volume,
@@ -54,7 +54,7 @@ export const useReactPlayerProps = (): UseReactPlayerProps => {
 	const listener = getListener();
 
 	const reactPlayerProps: ReactPlayerProps = {
-		autoPlay: initialState.isPlaying,
+		autoPlay,
 		playsinline: true,
 		playbackRate,
 		playing: isPlaying,

--- a/src/components/player/Player.tsx
+++ b/src/components/player/Player.tsx
@@ -34,6 +34,7 @@ export const Player: FC<PlayerProps> = memo(
 						attributes: {
 							crossOrigin: 'anonymous',
 							preload: 'false',
+							autoPlay: reactPlayerProps.autoPlay,
 						},
 					},
 				}}

--- a/src/components/player/usePlayerHook.ts
+++ b/src/components/player/usePlayerHook.ts
@@ -14,7 +14,7 @@ export const usePlayerHook = ({ url }: UsePlayerHookProps) => {
 	const [
 		reactPlayerRef,
 		mediaContainerRef,
-		initialState,
+		autoPlay,
 		isPlaying,
 		emitter,
 		onPause,
@@ -25,7 +25,7 @@ export const usePlayerHook = ({ url }: UsePlayerHookProps) => {
 		state => [
 			state.reactPlayerRef,
 			state.mediaContainerRef,
-			state.initialState,
+			state.autoPlay,
 			state.isPlaying,
 			state.emitter,
 			state.pause,
@@ -73,11 +73,7 @@ export const usePlayerHook = ({ url }: UsePlayerHookProps) => {
 	}, [emitter, onReadyToPlay, setCurrentTime]);
 
 	useLayoutEffect(() => {
-		if (
-			!hasAutoplayedRef.current &&
-			reactPlayerRef?.current &&
-			initialState?.isPlaying
-		) {
+		if (!hasAutoplayedRef.current && reactPlayerRef?.current && autoPlay) {
 			const el = reactPlayerRef?.current?.getInternalPlayer();
 			if (el && el.parentElement) {
 				el.parentElement?.focus();
@@ -88,7 +84,7 @@ export const usePlayerHook = ({ url }: UsePlayerHookProps) => {
 			emitter.on('ready', onReadyToSeek);
 		}
 		hasAutoplayedRef.current = true;
-	}, [emitter, initialState, onReadyToSeek, reactPlayerRef]);
+	}, [emitter, autoPlay, onReadyToSeek, reactPlayerRef]);
 
 	const hasAutoFocusedRef = useRef(false);
 

--- a/src/context/MediaProvider.tsx
+++ b/src/context/MediaProvider.tsx
@@ -76,7 +76,7 @@ export const MediaProvider: FC<MediaProviderProps> = ({
 
 	const contextValueRef = useRef(
 		createMediaStore({
-			initialState,
+			...initialState,
 			getHighlightColorBlended,
 			playPromiseRef,
 			reactPlayerRef,

--- a/src/store/media-store.ts
+++ b/src/store/media-store.ts
@@ -286,6 +286,27 @@ export const createSettersSlice: StateCreator<
 					});
 				}
 			}
+			// If autoplay is turned on, and video haven't played before
+			// then emit all "play" events
+			if (state.autoPlay && !state.hasPlayedOrSeeked) {
+				state.emitter.emit('timeupdate', {
+					seconds: currentRelativeTime,
+					duration: state.duration,
+				});
+				state.emitter.emit('progress', {
+					seconds: currentRelativeTime,
+					duration: state.duration,
+				});
+
+				return {
+					currentTime,
+					isPlaying: true,
+					currentTimeAlarm: newAlarmState.current,
+					nextTimeAlarm: newAlarmState.next,
+					hasPlayedOrSeeked: true,
+				};
+			}
+
 			if (state.isPlaying) {
 				state.emitter.emit('timeupdate', {
 					seconds: currentRelativeTime,

--- a/src/types/media-state-external-initializers.ts
+++ b/src/types/media-state-external-initializers.ts
@@ -11,11 +11,10 @@ import { MediaType } from './media-type';
  * State that initializes store external
  * @category MediaStore
  */
-export interface MediaStateExternalInitializers {
+export interface MediaStateExternalInitializers extends CorePlayerInitialState {
 	reactPlayerRef: RefObject<ReactPlayer>;
 	playPromiseRef: MutableRefObject<Promise<void> | undefined>;
 	mediaContainerRef: RefObject<HTMLDivElement>;
-	initialState: CorePlayerInitialState;
 	getHighlightColorBlended?: BlendColors;
 	onStoreUpdate?: (store: MediaStore) => void;
 	/** Trigger points (in sec) when an alert event is emitted */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -116,7 +116,6 @@ export const DEFAULT_EXTERNAL_STATE_SETTERS: MediaStateExternalInitializers = {
 	reactPlayerRef: { current: null },
 	playPromiseRef: { current: undefined },
 	mediaContainerRef: { current: null },
-	initialState: CORE_PLAYER_INITIAL_STATE,
 	getHighlightColorBlended: undefined,
 	onStoreUpdate: NO_OP,
 	alarms: [],
@@ -130,6 +129,7 @@ export const DEFAULT_EXTERNAL_STATE_SETTERS: MediaStateExternalInitializers = {
 	mediaType: 'video',
 	isAudio: false,
 	isPipEnabled: true,
+	...CORE_PLAYER_INITIAL_STATE,
 };
 
 export const DEFAULT_MEDIA_STORE_CONTEXT: MediaStore = {


### PR DESCRIPTION
As a part of :https://github.com/Collaborne/backlog/issues/1999
- Add `autoPlay` initial prop
- clean up non-working/unused/untested functionality of the `CorePlayerInitialState`

### Mentions
`CorePlayerInitialState`— not used in `c-app-ui`, and the only way we want to use it is to start with autoPlay, 