### PR TITLE
Keep control of media's total duration via `initialState` prop

### DIFF
--- a/.storybook/stories/14-InitialState.stories.tsx
+++ b/.storybook/stories/14-InitialState.stories.tsx
@@ -5,6 +5,8 @@ import {
 	CorePlayerProps,
 	PictureInPictureButton,
 	PlayPauseReplay,
+	ProgressBar,
+	TimeDisplay,
 } from '../../src/components';
 import { useBottomControlButtonsStyles } from '../../src/components/bottom-control-buttons/useBottomControlButtonsStyles';
 import { useControlsStyles } from '../../src/components/controls/useControlsStyles';
@@ -26,7 +28,9 @@ const Template: Story<Pick<CorePlayerProps, 'initialState'>> = args => {
 					<div className={wrapper}>
 						<PlayPauseReplay svgClassName="medium" />
 						<PictureInPictureButton />
+						<TimeDisplay sx={{ display: 'inline-flex', marginLeft: '16px' }} />
 					</div>
+					<ProgressBar />
 				</BottomControls>
 			</div>
 		</CorePlayer>
@@ -34,7 +38,7 @@ const Template: Story<Pick<CorePlayerProps, 'initialState'>> = args => {
 };
 
 export default {
-	title: 'CorePlayer',
+	title: 'CorePlayer / InitialState',
 	component: CorePlayer,
 	decorators: [withDemoCard],
 	parameters: {
@@ -42,15 +46,34 @@ export default {
 	},
 };
 
-export const InitialState: Story<CorePlayerProps> = Template.bind({});
-InitialState.args = {
+export const Autoplay: Story<CorePlayerProps> = Template.bind({});
+Autoplay.args = {
 	initialState: {
 		...CORE_PLAYER_INITIAL_STATE,
 		autoPlay: true,
 	},
 };
 
-InitialState.argTypes = {
+Autoplay.argTypes = {
+	initialState: {
+		name: 'props.initialState',
+		description: 'Initial state to configure CorePlayer',
+		table: {
+			type: { summary: 'CorePlayerInitialState' },
+			defaultValue: { summary: JSON.stringify(CORE_PLAYER_INITIAL_STATE) },
+		},
+	},
+};
+
+export const DurationSeconds: Story<CorePlayerProps> = Template.bind({});
+DurationSeconds.args = {
+	initialState: {
+		...CORE_PLAYER_INITIAL_STATE,
+		durationSeconds: 3,
+	},
+};
+
+DurationSeconds.argTypes = {
 	initialState: {
 		name: 'props.initialState',
 		description: 'Initial state to configure CorePlayer',

--- a/src/components/core-player/types.ts
+++ b/src/components/core-player/types.ts
@@ -5,8 +5,11 @@
 export interface CorePlayerInitialState {
 	/** Autoplay state. Forwarded to ReactPlayer */
 	autoPlay: boolean;
+	/** Media duration that will replace "real" media's duration. */
+	durationSeconds?: number;
 }
 
 export const CORE_PLAYER_INITIAL_STATE: CorePlayerInitialState = {
 	autoPlay: false,
+	durationSeconds: undefined,
 };

--- a/src/components/media-container/useReactPlayerProps.ts
+++ b/src/components/media-container/useReactPlayerProps.ts
@@ -19,7 +19,7 @@ export const useReactPlayerProps = (): UseReactPlayerProps => {
 	const [
 		reactPlayerRef,
 		playbackRate,
-		autoPlay,
+		initialState,
 		isPlaying,
 		isMuted,
 		volume,
@@ -35,7 +35,7 @@ export const useReactPlayerProps = (): UseReactPlayerProps => {
 		state => [
 			state.reactPlayerRef,
 			state.playbackRate,
-			state.autoPlay,
+			state.initialState,
 			state.isPlaying,
 			state.isMuted,
 			state.volume,
@@ -54,7 +54,7 @@ export const useReactPlayerProps = (): UseReactPlayerProps => {
 	const listener = getListener();
 
 	const reactPlayerProps: ReactPlayerProps = {
-		autoPlay,
+		autoPlay: initialState.autoPlay,
 		playsinline: true,
 		playbackRate,
 		playing: isPlaying,

--- a/src/components/player/usePlayerHook.ts
+++ b/src/components/player/usePlayerHook.ts
@@ -14,7 +14,7 @@ export const usePlayerHook = ({ url }: UsePlayerHookProps) => {
 	const [
 		reactPlayerRef,
 		mediaContainerRef,
-		autoPlay,
+		initialState,
 		isPlaying,
 		emitter,
 		onPause,
@@ -25,7 +25,7 @@ export const usePlayerHook = ({ url }: UsePlayerHookProps) => {
 		state => [
 			state.reactPlayerRef,
 			state.mediaContainerRef,
-			state.autoPlay,
+			state.initialState,
 			state.isPlaying,
 			state.emitter,
 			state.pause,
@@ -73,7 +73,11 @@ export const usePlayerHook = ({ url }: UsePlayerHookProps) => {
 	}, [emitter, onReadyToPlay, setCurrentTime]);
 
 	useLayoutEffect(() => {
-		if (!hasAutoplayedRef.current && reactPlayerRef?.current && autoPlay) {
+		if (
+			!hasAutoplayedRef.current &&
+			reactPlayerRef?.current &&
+			initialState.autoPlay
+		) {
 			const el = reactPlayerRef?.current?.getInternalPlayer();
 			if (el && el.parentElement) {
 				el.parentElement?.focus();
@@ -84,7 +88,7 @@ export const usePlayerHook = ({ url }: UsePlayerHookProps) => {
 			emitter.on('ready', onReadyToSeek);
 		}
 		hasAutoplayedRef.current = true;
-	}, [emitter, autoPlay, onReadyToSeek, reactPlayerRef]);
+	}, [emitter, initialState.autoPlay, onReadyToSeek, reactPlayerRef]);
 
 	const hasAutoFocusedRef = useRef(false);
 

--- a/src/context/MediaProvider.tsx
+++ b/src/context/MediaProvider.tsx
@@ -76,7 +76,7 @@ export const MediaProvider: FC<MediaProviderProps> = ({
 
 	const contextValueRef = useRef(
 		createMediaStore({
-			...initialState,
+			initialState,
 			getHighlightColorBlended,
 			playPromiseRef,
 			reactPlayerRef,

--- a/src/types/media-state-external-initializers.ts
+++ b/src/types/media-state-external-initializers.ts
@@ -1,7 +1,6 @@
 import { RefObject, MutableRefObject } from 'react';
 import type ReactPlayer from 'react-player';
 
-import { CorePlayerInitialState } from '../components';
 import { MediaStore } from '../store/media-store';
 import { BlendColors } from '../utils/colors';
 
@@ -11,7 +10,7 @@ import { MediaType } from './media-type';
  * State that initializes store external
  * @category MediaStore
  */
-export interface MediaStateExternalInitializers extends CorePlayerInitialState {
+export interface MediaStateExternalInitializers {
 	reactPlayerRef: RefObject<ReactPlayer>;
 	playPromiseRef: MutableRefObject<Promise<void> | undefined>;
 	mediaContainerRef: RefObject<HTMLDivElement>;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -129,11 +129,11 @@ export const DEFAULT_EXTERNAL_STATE_SETTERS: MediaStateExternalInitializers = {
 	mediaType: 'video',
 	isAudio: false,
 	isPipEnabled: true,
-	...CORE_PLAYER_INITIAL_STATE,
 };
 
 export const DEFAULT_MEDIA_STORE_CONTEXT: MediaStore = {
 	...DEFAULT_MEDIA_STATE,
 	...DEFAULT_MEDIA_STATE_SETTERS,
 	...DEFAULT_EXTERNAL_STATE_SETTERS,
+	initialState: CORE_PLAYER_INITIAL_STATE,
 };


### PR DESCRIPTION
- extend `CorePlayerInitialState` with durationSeconds field
- create a storybook to validate new created prop
- add `initialState` to the `MediaStore` and update `duration` from `initialState`(events emitting should not be broken) 