### PR TITLE
Remove transition for Slider(used in Progress Bars)

### DIFF
--- a/src/components/progress-bar/components/ProgressBarStyled.ts
+++ b/src/components/progress-bar/components/ProgressBarStyled.ts
@@ -34,7 +34,6 @@ export const ProgressBarStyled: StyledComponent<SliderProps> = styled(Slider)(
 
 			opacity: 0,
 			zIndex: 1,
-			transition: '.3s opacity ease-out',
 		},
 
 		'&:hover .MuiSlider-thumb': {


### PR DESCRIPTION
# Bug Description
When adding a transition(here we have set a 0.3s) =>  creates a delay between current progress + 0.3s, which causes inconsistency between UI (MuiThumb vs MuiTrack)
# Task|
- [x] Remove transition