### PR TITLE
Extend setters for fullscreen

### DIFF
--- a/src/components/media-container/MediaContainer.tsx
+++ b/src/components/media-container/MediaContainer.tsx
@@ -1,6 +1,7 @@
 import Grid from '@mui/material/Grid';
-import { FC, memo, useRef } from 'react';
+import { FC, memo, useEffect, useRef } from 'react';
 import intl from 'react-intl-universal';
+import screenfull from 'screenfull';
 import { shallow } from 'zustand/shallow';
 
 import { useMediaStore } from '../../context/MediaProvider';
@@ -54,16 +55,22 @@ export const MediaContainer: FC<MediaContainerProps> = memo(
 		const isAudio = useIsAudio();
 		// ref for the PIP area(pip will appear there)
 		const pipAreaRef = useRef<HTMLDivElement>(null);
-		const [mediaContainerRef, isPip, isFullscreen, isPipEnabled] =
-			useMediaStore(
-				state => [
-					state.mediaContainerRef,
-					state.isPip,
-					state.isFullscreen,
-					state.isPipEnabled,
-				],
-				shallow,
-			);
+		const [
+			mediaContainerRef,
+			isPip,
+			isFullscreen,
+			isPipEnabled,
+			setIsFullscreen,
+		] = useMediaStore(
+			state => [
+				state.mediaContainerRef,
+				state.isPip,
+				state.isFullscreen,
+				state.isPipEnabled,
+				state.setIsFullscreen,
+			],
+			shallow,
+		);
 		const {
 			classes: { wrapper, pipText, reactPlayer, pipArea },
 			cx,
@@ -82,6 +89,14 @@ export const MediaContainer: FC<MediaContainerProps> = memo(
 			isFullscreen,
 			reactPlayerProps,
 		};
+
+		useEffect(() => {
+			if (screenfull.isEnabled) {
+				screenfull.on('change', () => {
+					setIsFullscreen(screenfull.isFullscreen);
+				});
+			}
+		}, [mediaContainerRef, setIsFullscreen]);
 
 		const renderPlayer = () =>
 			isPipEnabled ? (

--- a/src/store/media-store.ts
+++ b/src/store/media-store.ts
@@ -75,6 +75,17 @@ export const createSettersSlice: StateCreator<
 			}
 			return { isFullscreen: false };
 		}),
+	setIsFullscreen: (isFullscreen: boolean) =>
+		set(state => {
+			if (state.isFullscreen !== isFullscreen) {
+				if (isFullscreen) {
+					state.emitter.emit('fullscreenEnter');
+				} else {
+					state.emitter.emit('fullscreenEnter');
+				}
+			}
+			return { isFullscreen };
+		}),
 	getListener: () => ({
 		addEventListener: get().emitter.on,
 		removeEventListener: get().emitter.off,

--- a/src/types/media-state-setters.ts
+++ b/src/types/media-state-setters.ts
@@ -21,6 +21,8 @@ export interface MediaStateSetters {
 	exitPip: () => void;
 	requestFullscreen: () => void;
 	exitFullscreen: () => void;
+	/** Setter for tracking fullscreen state. Do not calls `screenfull` methods */
+	setIsFullscreen: (isFullscreen: boolean) => void;
 	setShowControls: (isUpdated: boolean) => void;
 	setShowPipControls: (isUpdated: boolean) => void;
 	// Private Methods


### PR DESCRIPTION
# Mentions
fullscreen in the player is provided by `screenfull` package.
It can be triggered via buttons, or keyboard. As it is implemented for buttons only, it needs to be extended for all rest of the actions.
Fixes: https://github.com/Collaborne/backlog/issues/2070