### PR TITLE
Use common workspace typescript's settings for project

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+	"typescript.tsdk": "./node_modules/typescript/lib",
+	"typescript.enablePromptUseWorkspaceTsdk": true
+}


### PR DESCRIPTION
Fixes: https://github.com/Collaborne/backlog/issues/2048
- issue on **[stackoverflow](https://stackoverflow.com/questions/74642723/how-do-i-force-vs-code-to-always-use-my-workspaces-version-of-typescript-for-al)** 